### PR TITLE
add constraints to schema.rb

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,3 +12,4 @@ class User < ApplicationRecord
 
   has_many :products,dependent: :destroy
 end
+

--- a/db/migrate/20210620014619_change_column_to_products.rb
+++ b/db/migrate/20210620014619_change_column_to_products.rb
@@ -1,0 +1,10 @@
+class ChangeColumnToProducts < ActiveRecord::Migration[6.0]
+    def up
+      change_column :products, :name, :string, null:false, limit: 80
+      change_column :products, :description,:text,limit:250
+    end
+    def down
+      change_column :products, :name, :string, null:false
+      change_column :products, :description,:text
+    end
+end

--- a/db/migrate/20210620024158_change_column_tousers.rb
+++ b/db/migrate/20210620024158_change_column_tousers.rb
@@ -1,0 +1,10 @@
+class ChangeColumnTousers < ActiveRecord::Migration[6.0]
+  def up
+    change_column :users, :name, :string, null: false, limit: 50
+    change_column :users, :profile, :text, limit: 250
+  end
+  def down
+    change_column :users, :name, :string, null: false
+    change_column :users, :profile, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_19_002700) do
+ActiveRecord::Schema.define(version: 2021_06_20_024158) do
 
   create_table "product_techniques", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "product_id", null: false
@@ -20,8 +20,8 @@ ActiveRecord::Schema.define(version: 2021_06_19_002700) do
   end
 
   create_table "products", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "description"
+    t.string "name", limit: 80, null: false
+    t.text "description", size: :tiny
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "image"
@@ -43,9 +43,9 @@ ActiveRecord::Schema.define(version: 2021_06_19_002700) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "name", null: false
+    t.string "name", limit: 50, null: false
     t.boolean "admin", default: false
-    t.text "profile"
+    t.text "profile", size: :tiny
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
productsテーブルのnameカラム及びdescriptionカラムに、schemaの文字数制限をつけました。
また、usersテーブルのnameカラム及びprofileカラムにも、schemaの文字数制限をつけました。